### PR TITLE
Remove unused global variable gdt in vm.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ TOOLPREFIX := $(shell if i386-jos-elf-objdump -i 2>&1 | grep '^elf32-i386$$' >/d
 endif
 
 # If the makefile can't find QEMU, specify its path here
-#QEMU = 
+QEMU = qemu-system-i386
 
 # Try to infer the correct QEMU
 ifndef QEMU

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ UPROGS=\
 	_usertests\
 	_wc\
 	_zombie\
+	_cowtest\
 
 fs.img: mkfs README $(UPROGS)
 	./mkfs fs.img README $(UPROGS)

--- a/cowtest.c
+++ b/cowtest.c
@@ -1,0 +1,70 @@
+#include "types.h"
+#include "user.h"
+
+int nums[1000000];
+
+void fill(int n)
+{
+	int i;
+	for(i = 0; i < sizeof(nums) / sizeof(nums[0]); ++i)
+		nums[i] = n;
+}
+
+int check(int n)
+{
+	int i;
+	for(i = 0; i < sizeof(nums) / sizeof(nums[0]); ++i)
+		if(nums[i] != n)
+			return 1;
+	return 0;
+}
+
+int main()
+{
+	int i, pid;
+	printf(0, "Test the speed of fork...\n");
+	for(i = 0; i < 10; ++i)
+	{
+		pid = fork();
+		if(pid == 0)
+		{
+			exit();
+		}
+		else
+		{
+			pid = wait();
+		}
+	}
+	printf(0, "Finish\n");
+	printf(0, "Test the correctness of fork (Copy-On-Write)...\n");
+	fill(1);
+	pid = fork();
+	if(pid == 0)
+	{
+		fill(0);
+		exit();
+	}
+	else
+	{
+		pid = wait();
+		if(check(1))
+			printf(1, "Error\n");
+	}
+
+	pid = fork();
+	if(pid == 0)
+	{
+		sleep(200);
+		if(check(1))
+			printf(1, "Error\n");
+		exit();
+	}
+	else
+	{
+		fill(0);
+		pid = wait();
+	}
+
+	printf(0, "Finish\n");
+	exit();
+}

--- a/cowtest.c
+++ b/cowtest.c
@@ -1,5 +1,6 @@
 #include "types.h"
 #include "user.h"
+#include "fcntl.h"
 
 int nums[1000000];
 
@@ -21,7 +22,8 @@ int check(int n)
 
 int main()
 {
-	int i, pid;
+	int i, pid, fd;
+	char content = 'a';
 	printf(0, "Test the speed of fork...\n");
 	for(i = 0; i < 10; ++i)
 	{
@@ -48,7 +50,7 @@ int main()
 	{
 		pid = wait();
 		if(check(1))
-			printf(1, "Error\n");
+			printf(1, "Error in child write\n");
 	}
 
 	pid = fork();
@@ -56,7 +58,7 @@ int main()
 	{
 		sleep(200);
 		if(check(1))
-			printf(1, "Error\n");
+			printf(1, "Error in parent write\n");
 		exit();
 	}
 	else
@@ -65,6 +67,28 @@ int main()
 		pid = wait();
 	}
 
+	fd = open("cowtest_temp", O_CREATE|O_WRONLY);
+	write(fd, &content, 1);
+	close(fd);
+	content = 'b';
+
+	pid = fork();
+	if(pid == 0)
+	{
+		fd = open("cowtest_temp", O_RDONLY);
+		read(fd, &content, 1);
+		exit();
+	}
+	else
+	{
+		pid = wait();
+		if(content != 'b')
+			printf(1, "Error in child kernel write\n");
+	}
+
+	unlink("cowtest_temp");
+
 	printf(0, "Finish\n");
+
 	exit();
 }

--- a/defs.h
+++ b/defs.h
@@ -176,6 +176,7 @@ void            switchuvm(struct proc*);
 void            switchkvm(void);
 int             copyout(pde_t*, uint, void*, uint);
 void            clearpteu(pde_t *pgdir, char *uva);
+void            pagefault(uint err_code);
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x)/sizeof((x)[0]))

--- a/fcntl.h
+++ b/fcntl.h
@@ -2,3 +2,4 @@
 #define O_WRONLY  0x001
 #define O_RDWR    0x002
 #define O_CREATE  0x200
+#define O_APPEND  0x400

--- a/file.c
+++ b/file.c
@@ -138,6 +138,8 @@ filewrite(struct file *f, char *addr, int n)
 
       begin_trans();
       ilock(f->ip);
+      if (f->append)
+        f->off = f->ip->size;
       if ((r = writei(f->ip, addr + i, f->off, n1)) > 0)
         f->off += r;
       iunlock(f->ip);

--- a/file.h
+++ b/file.h
@@ -3,6 +3,7 @@ struct file {
   int ref; // reference count
   char readable;
   char writable;
+  char append;
   struct pipe *pipe;
   struct inode *ip;
   uint off;

--- a/sh.c
+++ b/sh.c
@@ -390,7 +390,7 @@ parseredirs(struct cmd *cmd, char **ps, char *es)
       cmd = redircmd(cmd, q, eq, O_WRONLY|O_CREATE, 1);
       break;
     case '+':  // >>
-      cmd = redircmd(cmd, q, eq, O_WRONLY|O_CREATE, 1);
+      cmd = redircmd(cmd, q, eq, O_WRONLY|O_CREATE|O_APPEND, 1);
       break;
     }
   }

--- a/sysfile.c
+++ b/sysfile.c
@@ -315,6 +315,7 @@ sys_open(void)
   f->off = 0;
   f->readable = !(omode & O_WRONLY);
   f->writable = (omode & O_WRONLY) || (omode & O_RDWR);
+  f->append = ((omode & O_APPEND) != 0);
   return fd;
 }
 

--- a/trap.c
+++ b/trap.c
@@ -47,6 +47,9 @@ trap(struct trapframe *tf)
   }
 
   switch(tf->trapno){
+  case T_PGFLT:
+    pagefault(tf->err);
+    break;
   case T_IRQ0 + IRQ_TIMER:
     if(cpu->id == 0){
       acquire(&tickslock);

--- a/vm.c
+++ b/vm.c
@@ -9,7 +9,6 @@
 
 extern char data[];  // defined by kernel.ld
 pde_t *kpgdir;  // for use in scheduler()
-struct segdesc gdt[NSEGS];
 
 // Set up CPU's kernel segment descriptors.
 // Run once on entry on each CPU.


### PR DESCRIPTION
It seems that this variable is not used anywhere. Removing this variable makes the code more clear.
